### PR TITLE
refactor: creation of the dataframe for the sequential scenario

### DIFF
--- a/experiment-setup/execution/data_collection.py
+++ b/experiment-setup/execution/data_collection.py
@@ -55,11 +55,11 @@ def generate_output(otii_project, device):
 
 def save_sequential_time(dataframe_api, dataframe_page, recording_name, service_name, out_path):
     """Save sequential time data for API and Page as JSON files."""
-    api_path = Path(out_path, f"{service_name}-sequential-time-api-{recording_name}.json")
-    page_path = Path(out_path, f"sequential-time-page-{recording_name}.json")
-
-    dataframe_api.to_json(api_path, orient="records", lines=True)
-    dataframe_page.to_json(page_path, orient="records", lines=True)
+    api_path = Path(out_path, f"{service_name}-sequential-time-api-{recording_name}.csv")
+    page_path = Path(out_path, f"sequential-time-page-{recording_name}.csv")
+    
+    dataframe_api.to_csv(api_path, index=False)
+    dataframe_page.to_csv(page_path, index=False)
 
 def save_data(dataframe, recording_name, out_path, scenario_name, service_name):
     """Save the collected data as a CSV file."""

--- a/experiment-setup/execution/execution.py
+++ b/experiment-setup/execution/execution.py
@@ -38,7 +38,7 @@ async def main(otii_project, device, out_path, service, run_mode):
             print(result_clients_trigger, flush=True)
         elif run_mode == "sequential":
             time_seq_api_df = run_api_seq_scenario(service, start_time)
-            reset = clean_database(False)
+            clean_database(False)
             time_seq_page_df = run_page_seq_scenario(service, start_time)
         otii_project.stop_recording()
         t_delta = datetime.now() - start_time
@@ -46,7 +46,8 @@ async def main(otii_project, device, out_path, service, run_mode):
         print(f"Done with scenario {run_mode} for service {service}...", flush=True)
         df, recording_name = collect_data(otii_project, device)
         if time_seq_api_df is not None and time_seq_page_df is not None:
-            save_sequential_time(time_seq_api_df, time_seq_page_df, recording_name, service, out_path)
+            save_data(time_seq_api_df, recording_name, out_path, run_mode, service)
+            save_data(time_seq_page_df, recording_name, out_path, run_mode, service)
         save_data(df, recording_name, out_path, run_mode, service)
         generate_output(otii_project, device)
         

--- a/experiment-setup/execution/execution.py
+++ b/experiment-setup/execution/execution.py
@@ -46,8 +46,7 @@ async def main(otii_project, device, out_path, service, run_mode):
         print(f"Done with scenario {run_mode} for service {service}...", flush=True)
         df, recording_name = collect_data(otii_project, device)
         if time_seq_api_df is not None and time_seq_page_df is not None:
-            save_data(time_seq_api_df, recording_name, out_path, run_mode, service)
-            save_data(time_seq_page_df, recording_name, out_path, run_mode, service)
+            save_sequential_time(time_seq_api_df, time_seq_page_df, recording_name, service, out_path)
         save_data(df, recording_name, out_path, run_mode, service)
         generate_output(otii_project, device)
         

--- a/experiment-setup/execution/host_sequence/scenario_api.py
+++ b/experiment-setup/execution/host_sequence/scenario_api.py
@@ -21,101 +21,91 @@ def request_endpoint(path, method="get", data=None, params=None, user_session=No
     response = (user_session or session).request(method=method, url=url, json=data, params=params, headers=AUTH_HEADER)
     end = time.time()
     print(f"Request to {url:<40} | Status: {response.status_code:<3} | start: {start:<20.6f} | end: {end:<20.6f}")
-    return {"endpoint": path, "response": response.status_code, "text": response.text, "start": start, "end": end,
+    return {"endpoint": f"/api{path}", "response": response.status_code, "text": response.text, "start": start, "end": end,
             "delta": end - start}
 
 
 def sequential_interval_scenario(service, start, iter):
-    # set main user
+    # set main user and dataframe
     main_user = api_register_data_dummie(0)["username"]
+    results = []
+
+    # 0. Health check call public endpoint
+    print_info_call("API", service, "Health check", 1)
+    request_endpoint("/public", method="get")
 
     # 1. Register all users
     print_info_call("API", service, "Register", ITER_NUM)
-    api_register_response = []
     for i in range(ITER_NUM):
         user_register_data = api_register_data_dummie(i)
         response = request_endpoint("/register", method="post", data=user_register_data, params=api_latest_query)
-        api_register_response.append(response)
+        results.append(response)
         user_sessions[user_register_data["username"]] = requests.Session()
     time.sleep(BASE_DELAY)
 
     # 2. User 1 post messages
     print_info_call("API", service, "Post messages", ITER_NUM)
     main_user_session = user_sessions[main_user]
-    api_message_response = [
-        request_endpoint(f"/msgs/{main_user}", method="post", data=api_message_data, params=api_latest_query) for _ in range(ITER_NUM)
-    ]
+    for _ in range(ITER_NUM):
+        response = request_endpoint(f"/msgs/{main_user}", method="post", data=api_message_data, params=api_latest_query)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 3. Retrieve public messages
     print_info_call("API", service, "Retrieve public messages", ITER_NUM)
-    api_public_msgs = [request_endpoint("/msgs", method="get", params={**api_message_amount, **api_latest_query}) for _
-                       in range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint("/msgs", method="get", params={**api_message_amount, **api_latest_query})
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 4. Retrieve user messages
     print_info_call("API", service, "Retrieve user messages", ITER_NUM)
-    api_user_msgs = [
-        request_endpoint(f"/msgs/{main_user}", method="get", params={**api_message_amount, **api_latest_query}) for _ in
-        range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint(f"/msgs/{main_user}", method="get", params={**api_message_amount, **api_latest_query})
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 5. All users follow user1
     print_info_call("API", service, "Follow users", ITER_NUM)
-    api_follow_user_1 = []
     for i in range(ITER_NUM):
         follow = api_follow_data_dummie(i)
         user_session = user_sessions[follow["follow"]]
         response = request_endpoint(f"/fllws/{follow['follow']}", method="post", data={"follow": "user1"},
                                     params=api_latest_query, user_session=user_session)
-        api_follow_user_1.append(response)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 6. Get followers for user one
     print_info_call("API", service, "Get followers", ITER_NUM)
-    api_user_followers = [request_endpoint("/fllws/user1", method="get",
-                                           params={**api_message_amount, **api_latest_query},
-                                           user_session=main_user_session) for _ in range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint("/fllws/user1", method="get", params={**api_message_amount, **api_latest_query},
+                                    user_session=main_user_session)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 7. All users unfollow user1
     print_info_call("API", service, "Unfollow users", ITER_NUM)
-    api_unfollow_user_1 = []
     for i in range(ITER_NUM):
         unfollow = api_unfollow_data_dummie(i)
         user_session = user_sessions[unfollow["unfollow"]]
         response = request_endpoint(f"/fllws/{unfollow['unfollow']}", method="post", data={"unfollow": "user1"},
                                     params=api_latest_query, user_session=user_session)
-        api_unfollow_user_1.append(response)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 8. Retrieve the latest status
     print_info_call("API", service, "Retrieve latest status", ITER_NUM)
-    api_latest = [request_endpoint("/latest", method="get") for _ in range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint("/latest", method="get", params=api_latest_query)
+        results.append(response)
 
     print(f"Finished API sequence for service {service} - iteration {iter}!", flush=True)
 
-    return [f"{service}-api-{start}-{iter}",
-            api_register_response,
-            api_message_response,
-            api_public_msgs,
-            api_user_msgs,
-            api_follow_user_1,
-            api_user_followers,
-            api_unfollow_user_1,
-            api_latest]
+    return results
 
 
 def run_api_seq_scenario(service, start):
-    data = [sequential_interval_scenario(service, start, 0)]
-    df = pd.DataFrame(data, columns=["ExperimentID",
-                                     "ApiRegisterResponse",
-                                     "ApiMessageResponse",
-                                     "ApiPublicMsgsResponse",
-                                     "ApiUserMsgsResponse",
-                                     "ApiFollowsUserResponse",
-                                     "ApiUserFollowersResponse",
-                                     "ApiUnfollowsUserResponse",
-                                     "ApiLatestResponse"
-                                     ])
+    responses = sequential_interval_scenario(service, start, 0)
+    df = pd.DataFrame(responses)
+
     return df

--- a/experiment-setup/execution/host_sequence/scenario_page.py
+++ b/experiment-setup/execution/host_sequence/scenario_page.py
@@ -25,8 +25,13 @@ def request_endpoint(path, method="get", data=None, user_session=None):
 
 
 def sequential_interval_scenario(service, start, iter):
-    # set main user
+    # set main user and results
     main_user = register_data_dummie(0)["username"]
+    results = []
+
+    # 0. Health check call public endpoint
+    print_info_call("Page", service, "Health check", 1)
+    request_endpoint("/public", method="get")
 
     # 1. Access Public Timeline
     print_info_call("Page", service, "Public Timeline", ITER_NUM)
@@ -35,99 +40,76 @@ def sequential_interval_scenario(service, start, iter):
 
     # 2. Register all 400 users
     print_info_call("Page", service, "Register", ITER_NUM)
-    register_response = []
     for i in range(ITER_NUM):
         user = register_data_dummie(i)
         response = request_endpoint("/register", method="post", data=user)
-        register_response.append(response)
-        # Create a session for each user after registration
+        results.append(response)
         user_sessions[user["username"]] = requests.Session()
     time.sleep(BASE_DELAY)
 
     # 3. Login with all 400 users
     print_info_call("Page", service, "Login", ITER_NUM)
-    login_response = []
     for i in range(ITER_NUM-1, -1, -1):
         user = login_data_dummie(i)
         user_session = user_sessions[user["username"]]
         response = request_endpoint("/login", method="post", data=user, user_session=user_session)
-        login_response.append(response)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 4. main user follows all other users
     print_info_call("Page", service, "Follow", ITER_NUM)
-    follow_response = []
     main_user_session = user_sessions[main_user]
     for i in range(1, ITER_NUM):  # Start from the second user to avoid self-following
         user = login_data_dummie(i)
         whom_username = user["username"]
         response = request_endpoint(f"/{whom_username}/follow", user_session=main_user_session)
-        follow_response.append(response)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 5. User 1 posts a message
     print_info_call("Page", service, "Post Message", ITER_NUM)
-    message_response = [
-        request_endpoint("/add_message", method="post", data=message_data, user_session=main_user_session) for _ in
-        range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint("/add_message", method="post", data=message_data, user_session=main_user_session)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 6. Access public timeline
     print_info_call("Page", service, "Public Timeline Redirect", ITER_NUM)
-    public_timeline_redirect_response = [request_endpoint("/public") for _ in range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint("/public")
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 7. Access user timeline
     print_info_call("Page", service, "User Timeline", ITER_NUM)
-    user_timeline_response = [request_endpoint(f"/{main_user}", user_session=main_user_session) for _ in range(ITER_NUM)]
+    for _ in range(ITER_NUM):
+        response = request_endpoint(f"/{main_user}", user_session=main_user_session)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 8. Unfollow all users
     print_info_call("Page", service, "Unfollow", ITER_NUM)
-    unfollow_response = []
     for i in range(ITER_NUM):
         user = login_data_dummie(i)
         whom_username = user["username"]
         response = request_endpoint(f"/{whom_username}/unfollow", user_session=main_user_session)
-        unfollow_response.append(response)
+        results.append(response)
     time.sleep(BASE_DELAY)
 
     # 9. Logout all users
     print_info_call("Page", service, "Logout", ITER_NUM)
-    logout_response = []
     for i in range(ITER_NUM):
         user = login_data_dummie(i)
         user_session = user_sessions[user["username"]]
         response = request_endpoint("/logout", user_session=user_session)
-        logout_response.append(response)
-    time.sleep(BASE_DELAY)
+        results.append(response)
 
     print(f"Finished page sequence for service {service} - iteration {iter}!", flush=True)
 
-    return [f"{service}-page-{start}-{iter}",
-            public_page_response,
-            register_response,
-            login_response,
-            follow_response,
-            message_response,
-            public_timeline_redirect_response,
-            user_timeline_response,
-            unfollow_response,
-            logout_response]
+    return results
 
 
 def run_page_seq_scenario(service, start):
-    data = [sequential_interval_scenario(service, start, 0)]
-    df = pd.DataFrame(data, columns=[
-        "ExperimentID",
-        "PublicPageResponse",
-        "RegisterResponse",
-        "LoginResponse",
-        "FollowResponse",
-        "AddMessageResponse",
-        "PublicTimelineRedirectResponse",
-        "UserTimelineResponse",
-        "UnfollowResponse",
-        "LogoutResponse"
-    ])
+    responses = sequential_interval_scenario(service, start, 0)
+    df = pd.DataFrame(responses)
     return df


### PR DESCRIPTION
Changed the creation of the data frame for the sequential scenario for better readability in the `data-analysis` pipeline. 
The data will now be outputted like this:
```
 endpoint  response         start           end     delta
0  /public       200  1.731868e+09  1.731868e+09  0.132186
1  /public       200  1.731868e+09  1.731868e+09  0.110442
2  /public       200  1.731868e+09  1.731868e+09  0.101596
3  /public       200  1.731868e+09  1.731868e+09  0.083600
4  /public       200  1.731868e+09  1.731868e+09  0.101453
```