### PR TITLE
fix: scenario api endpoint `fllws` 

### DIFF
--- a/experiment-setup/execution/host_sequence/scenario_api.py
+++ b/experiment-setup/execution/host_sequence/scenario_api.py
@@ -90,6 +90,7 @@ def sequential_interval_scenario(service, start, iter):
         user_session = user_sessions[unfollow["unfollow"]]
         response = request_endpoint(f"/fllws/{unfollow['unfollow']}", method="post", data={"unfollow": "user0"},
                                     params=api_latest_query, user_session=user_session)
+        response['endpoint'] = response['endpoint'].replace('fllws', 'unfllw')
         results.append(response)
     time.sleep(BASE_DELAY)
 


### PR DESCRIPTION
Endpoint fix for `sequential` scenario `fllws` to be able to make them consistent in the data analysis pipeline