### PR TITLE
fix: user endpoint and gunicorn layer using worker calculation

### DIFF
--- a/python-flask/Dockerfile
+++ b/python-flask/Dockerfile
@@ -16,4 +16,4 @@ COPY . /app
 EXPOSE 5000
 ENV FLASK_APP=wsgi.py
 
-CMD ["venv/bin/gunicorn", "--bind", "0.0.0.0:5000", "wsgi:app"]
+CMD ["sh", "-c", "venv/bin/gunicorn --workers $((2 * $(nproc) + 1)) --bind 0.0.0.0:5000 wsgi:app"]

--- a/python-flask/app/main/routes.py
+++ b/python-flask/app/main/routes.py
@@ -77,7 +77,7 @@ def public_timeline():
     return render_template("timeline.html", messages=messages_with_users)
 
 
-@main_bp.route("/<username>")
+@main_bp.route("/user/<username>")
 def user_timeline(username):
     """Displays a user's timeline."""
     is_user_logged()


### PR DESCRIPTION
PR includes endpoint changes for `/user` endpoint and a worker calculation for the the gunicorn layer