### PR TITLE
feat: remove logging from javascript-express

### DIFF
--- a/javascript-express/src/app.js
+++ b/javascript-express/src/app.js
@@ -1,7 +1,6 @@
 const express = require('express');
 let path = require('path');
 const cookieParser = require('cookie-parser');
-const logger = require('morgan');
 const flash = require('express-flash');
 const session = require('express-session');
 const expressLayouts = require('express-ejs-layouts');
@@ -24,7 +23,6 @@ app.use(
 
 app.use(expressLayouts);
 app.set('layout', 'layout.ejs');
-app.use(logger('dev'));
 app.use(flash());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/javascript-express/src/database/model.js
+++ b/javascript-express/src/database/model.js
@@ -16,6 +16,7 @@ const connectionOptions =
                       rejectUnauthorized: false,
                   },
               },
+              logging: false,
           };
 
 const sequelize = new Sequelize(databaseUrl, {


### PR DESCRIPTION
This PR removes logging from the javascript-express application.

This is consistent with all other applications.

We could add a conditional environment check (DEV vs PROD) and enable/disable logging based on that.

But I have chosen not to since all the other applications do not.

Adding a conditional check would of course not interfere with the measurements since this operation would be perfomed when the application is being spun up in the docker container and thereby not during the requests from berries.
